### PR TITLE
Automatically switches app theme based on the settings from the system

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,18 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import { useEffect } from "react";
 
 export default function App({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (e.matches) document.documentElement.classList.add('dark');
+      else document.documentElement.classList.remove('dark');
+    });
+  }, []);
+
   return <Component {...pageProps} />;
 }


### PR DESCRIPTION
This PR updates the base template to support automatically switching the theme of the app based on the system settings.

Based on Tailwind's docs: https://tailwindcss.com/docs/dark-mode#with-system-theme-support

<img width="703" alt="image" src="https://github.com/user-attachments/assets/1f1e7716-565c-461d-b5b5-ba6041389b6c" />

